### PR TITLE
Naam signaalkreeft veranderen

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -12,7 +12,7 @@
     href: /soorten/astacus-astacus/
   - text: Turkse rivierkreeft
     href: /soorten/pontastacus-leptodactylus/
-  - text: Signaalkreeft
+  - text: Californische rivierkreeft
     href: /soorten/pacifastacus-leniusculus/
   - text: Rode Amerikaanse rivierkreeft
     href: /soorten/procambarus-clarkii/


### PR DESCRIPTION
Is nu Californische rivierkreeft zoals op Waarnemingen om verwarring te vermijden.