### PR TITLE
New layout for species

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -3,23 +3,7 @@
 - text: Team
   href: /team/
 - text: Soorten
-  menu:
-  - text: Gevlekte Amerikaanse rivierkreeft
-    href: /soorten/faxonius-limosus/
-  - text: Geknobbelde Amerikaanse rivierkreeft
-    href: /soorten/faxonius-virilis/
-  - text: Europese rivierkreeft
-    href: /soorten/astacus-astacus/
-  - text: Turkse rivierkreeft
-    href: /soorten/pontastacus-leptodactylus/
-  - text: Californische rivierkreeft
-    href: /soorten/pacifastacus-leniusculus/
-  - text: Rode Amerikaanse rivierkreeft
-    href: /soorten/procambarus-clarkii/
-  - text: Marmerkreeft
-    href: /soorten/procambarus-virginalis/
-  - text: Gestreepte Amerikaanse rivierkreeft
-    href: /soorten/procambarus-acutus/
+  href: /soorten/
 - text: Doe mee
   menu:
   - text: Meld je aan

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -1,0 +1,62 @@
+---
+layout: base
+description: Template for a list of posts or page.pages as cards, with full width.
+---
+
+<div class="row">
+  <div class="col content">
+
+    {{ content }}
+  
+  </div>
+</div>
+
+{% if page.pages %}
+  {% assign archive = "pages" %}
+  {% assign items = "" | split: "" %}
+  {% for listed_page in page.pages %}
+    {% assign internal_page = site.pages | where: 'url', listed_page.href | first %}
+    {% if internal_page %}
+      {% assign items = items | push: internal_page %}
+    {% endif %}
+  {% endfor %}
+{% else %}
+  {% assign archive = "posts" %}
+  {% assign items = site.posts %}
+{% endif %}
+
+<div class="row cards">
+  {% for item in items %}
+    <div class="col-md-6 col-lg-4">
+      {% include card.html %}
+    </div>
+  {% endfor %}
+</div>
+
+{% if archive == "posts" %}
+<script>
+  // Filter cards on ?tag=value
+  $(document).ready(function() {
+    const urlParams = new URLSearchParams(window.location.search);
+    
+    if (urlParams.has("tag") && urlParams.get("tag") != "") {
+      const tag = urlParams.get("tag"); // Will return 1st tag value + decode URI
+      const cleanTag = $.trim(tag.toLowerCase()); // Create tag as written in .card data-tags
+      
+      $(".card").each(function() {
+        const cardTags = $(this).data("tags").split("|");
+        // Hide card if it does not contain the selected tag
+        if (!cardTags.includes(cleanTag)) {
+          $(this).parent().addClass("d-none");
+        }
+      });
+
+      $(".header .tags").append(
+        '<a class="badge{% if site.rounded_corners != false %} rounded-pill{% endif %}" href="{{ site.archive_permalink | relative_url }}">' + 
+        tag + '<span class="btn-close btn-close-white"></span>' + 
+        '</a>'
+      );
+    }
+  });
+</script>
+{% endif %}

--- a/pages/soorten/index.md
+++ b/pages/soorten/index.md
@@ -1,0 +1,14 @@
+---
+layout: archive
+title: Soorten
+permalink: /soorten/
+pages:
+- href: /soorten/faxonius-limosus/
+- href: /soorten/faxonius-virilis/
+- href: /soorten/astacus-astacus/
+- href: /soorten/pontastacus-leptodactylus/
+- href: /soorten/pacifastacus-leniusculus/
+- href: /soorten/procambarus-clarkii/
+- href: /soorten/procambarus-virginalis/
+- href: /soorten/procambarus-acutus/
+---


### PR DESCRIPTION
Fixes #41

This PR provides an overview of the species on one page, with photos, as discussed in #41. It is implemented using a custom layout:

- In the overview page (`soorten/index.md`) list pages in `pages`. You need to provide the `href`
- The layout than automatically looks up the page via `href` and gets the `title`, `description` and `background` (so that info does not need to be repeated)
- It displays the pages as cards.
- Note: currently, some pages don't have a background image yet, but do define it in `background`. That currently results in a broken image link. It can be resolved by adding an image, or removing the `background` (and `by`, `href`, etc.) property altogether.

@biekemaex let me know if this is ok

![Soorten-Craywatch](https://github.com/inbo/craywatch/assets/600993/a668870c-0f07-41b6-9ad3-28022b4d7cbe)
