### PR TITLE
Remove clustering

### DIFF
--- a/_layouts/map.html
+++ b/_layouts/map.html
@@ -30,9 +30,6 @@ description: Template for a leaflet map with the observations
   }
 </style>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
-<link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster/dist/MarkerCluster.css" />
-<link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster/dist/MarkerCluster.Default.css" />
-<script src="https://unpkg.com/leaflet.markercluster/dist/leaflet.markercluster.js"></script>
 <script src="https://d3js.org/d3.v7.min.js"></script>
 <script>
   // Initialize the map

--- a/_layouts/map.html
+++ b/_layouts/map.html
@@ -102,9 +102,9 @@ description: Template for a leaflet map with the observations
 
   // Layer groups for markers
   const markersLayer = L.layerGroup();
-  const newOccsLayers = L.markerClusterGroup();
-  const histOccsLayers = L.markerClusterGroup();
-  const absencesLayer = L.markerClusterGroup();
+  const newOccsLayers = L.layerGroup();
+  const histOccsLayers = L.layerGroup();
+  const absencesLayer = L.layerGroup();
 
   // Function to read the CSV file
   async function readAndShow(csvFile) {


### PR DESCRIPTION
As expressed by @fjasteen in the craywatch chat, clustering can be confusing and doesn't allow the user to have an idea about the general distribution of observations per species.

Notice that adding/removing clustering is quite straightforward. So easy to be set back if needed.