### PR TITLE
Spiderfying observations

### DIFF
--- a/_layouts/map.html
+++ b/_layouts/map.html
@@ -31,11 +31,44 @@ description: Template for a leaflet map with the observations
 </style>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
 <script src="https://d3js.org/d3.v7.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/OverlappingMarkerSpiderfier-Leaflet/0.2.6/oms.min.js"></script>
 <script>
   // Initialize the map
   var map = L.map('map', {
     center: [51.0, 4.15], // Set the center of the map
     zoom: 8                // Set the zoom level
+  });
+
+  // Initialize the spiderfier
+  var oms = new OverlappingMarkerSpiderfier(map, {
+    keepSpiderfied: true,
+    nearbyDistance: 20,
+    circleSpiralSwitchover: 9,
+    legWeight: 1
+  });
+
+  map.on('zoomend', function() {
+    oms.unspiderfy();
+  });
+
+  map.on('moveend', function() {
+    oms.unspiderfy();
+  });
+
+  var popup = new L.Popup();
+  oms.addListener('click', function(marker) {
+    map.closePopup(); // Close any open popups
+    popup.setContent(marker.getPopup().getContent());
+    popup.setLatLng(marker.getLatLng());
+    map.openPopup(popup);
+  });
+  
+  oms.addListener('spiderfy', function(markers) {
+    map.closePopup(); // Close any open popups
+  });
+  
+  oms.addListener('unspiderfy', function(markers) {
+    map.closePopup(); // Close any open popups
   });
 
   // Define tile layers (background layers)
@@ -196,8 +229,9 @@ description: Template for a leaflet map with the observations
         }
         // Add popup
         circle.bindPopup(popupContent);
-        // Add circle to layer
+        // Add circle to layer and spiderfier
         occsLayer.addLayer(circle);
+        oms.addMarker(circle);
       }
     });
     return occsLayer;
@@ -236,6 +270,10 @@ description: Template for a leaflet map with the observations
     await readAndShowJSON(absencesUrl, absencesLayer);
     // Call the functions to read the historical occurrences (JSON) and add them to the leaflet map
     await readAndShowJSON(historicalDataUrl, histOccsLayer);
+    // Add all markers to the spiderfier
+    newOccsLayer.eachLayer(marker => oms.addMarker(marker));
+    absencesLayer.eachLayer(marker => oms.addMarker(marker));
+    histOccsLayer.eachLayer(marker => oms.addMarker(marker));
   }
   
   // Execute main function when the script loads

--- a/_layouts/map.html
+++ b/_layouts/map.html
@@ -28,6 +28,10 @@ description: Template for a leaflet map with the observations
     margin-right: 8px;
     opacity: 0.7;
   }
+  .custom-div-icon {
+    background: transparent;
+    border: none;
+  }
 </style>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
 <script src="https://d3js.org/d3.v7.min.js"></script>
@@ -47,11 +51,7 @@ description: Template for a leaflet map with the observations
     legWeight: 1
   });
 
-  map.on('zoomend', function() {
-    oms.unspiderfy();
-  });
-
-  map.on('moveend', function() {
+  map.on('zoomend moveend', function() {
     oms.unspiderfy();
   });
 
@@ -62,11 +62,11 @@ description: Template for a leaflet map with the observations
     popup.setLatLng(marker.getLatLng());
     map.openPopup(popup);
   });
-  
+
   oms.addListener('spiderfy', function(markers) {
     map.closePopup(); // Close any open popups
   });
-  
+
   oms.addListener('unspiderfy', function(markers) {
     map.closePopup(); // Close any open popups
   });
@@ -210,33 +210,31 @@ description: Template for a leaflet map with the observations
       const lat = parseFloat(item.decimalLatitude);
       const lon = parseFloat(item.decimalLongitude);
       if (!isNaN(lat) && !isNaN(lon)) {
-        const speciesInfo = speciesColorsVernacularNames[item.species] || {color: 'gray', vernacularName: 'null'};
-        const circle = L.circleMarker([lat, lon], {
-            radius: 5, 
-            color: speciesInfo.color,
-            fillColor: speciesInfo.color,
-            fillOpacity: 0.95,
-            stroke: false
+        const speciesInfo = speciesColorsVernacularNames[item.species] || {color: 'gray',   vernacularName: 'null'};
+        const marker = L.marker([lat, lon], {
+          icon: L.divIcon({
+            className: 'custom-div-icon',
+            html: `<div style="background-color:${speciesInfo.color}; width:10px; height:10px;  border-radius:50%;"></div>`,
+            iconSize: [10, 10],
+            iconAnchor: [5, 5]
+          })
         });
         // Create basic popup content
         let popupContent = `<b>${speciesInfo.vernacularName}</b><br>${item.eventDate}`;
         if (item.references) {
-          // Add reference link if present, typically with link to observation on waarnemingen.be
           popupContent += `<br><a href="${item.references}" target="_blank">${item.references}</a>`;
         } else {
-          // Add link to the occurrence as published on GBIF
-          popupContent += `<br><a href="https://www.gbif.org/occurrence/${item.key}" target="_blank">https://www.gbif.org/occurrence/${item.key}</a>`;
+          popupContent += `<br><a href="https://www.gbif.org/occurrence/${item.key}"  target="_blank">https://www.gbif.org/occurrence/${item.key}</a>`;
         }
         // Add popup
-        circle.bindPopup(popupContent);
-        // Add circle to layer and spiderfier
-        occsLayer.addLayer(circle);
-        oms.addMarker(circle);
+        marker.bindPopup(popupContent);
+        // Add marker to layer and spiderfier
+        occsLayer.addLayer(marker);
+        oms.addMarker(marker);
       }
     });
     return occsLayer;
   }
-
   // Function to read the JSON data from the API and add them to the leaflet map
   async function readAndShowJSON(apiUrl, occsLayer) {
     // Call the function to fetch all data

--- a/_layouts/map.html
+++ b/_layouts/map.html
@@ -99,8 +99,8 @@ description: Template for a leaflet map with the observations
 
   // Layer groups for markers
   const markersLayer = L.layerGroup();
-  const newOccsLayers = L.layerGroup();
-  const histOccsLayers = L.layerGroup();
+  const newOccsLayer = L.layerGroup();
+  const histOccsLayer = L.layerGroup();
   const absencesLayer = L.layerGroup();
 
   // Function to read the CSV file
@@ -230,12 +230,12 @@ description: Template for a leaflet map with the observations
     // Call the functions to read the CSV and add the results to the leaflet
     readAndShow(localitiesURL);
     // Call the functions to read the recent occurrences (JSON) and add them to the leaflet map
-    await readAndShowJSON(recentDataUrl, newOccsLayers);
-    newOccsLayers.addTo(map);
+    await readAndShowJSON(recentDataUrl, newOccsLayer);
+    newOccsLayer.addTo(map);
     // Call the functions to read the recent absences (JSON) and add them to the leaflet map
     await readAndShowJSON(absencesUrl, absencesLayer);
     // Call the functions to read the historical occurrences (JSON) and add them to the leaflet map
-    await readAndShowJSON(historicalDataUrl, histOccsLayers);
+    await readAndShowJSON(historicalDataUrl, histOccsLayer);
   }
   
   // Execute main function when the script loads
@@ -250,8 +250,8 @@ description: Template for a leaflet map with the observations
     },
     {
       'Gereserveerde locaties': markersLayer,
-      'Nieuwe waarnemingen': newOccsLayers,
-      'Historische waarnemingen': histOccsLayers,
+      'Nieuwe waarnemingen': newOccsLayer,
+      'Historische waarnemingen': histOccsLayer,
       'Null waarnemingen': absencesLayer
     },
     {


### PR DESCRIPTION
This PR solves #288

In particular:
- observations with same lat/lon are now spiderfied (see screenshot below)
- spiderfying disappears while zooming out/in, moving the background map or clicking anywhere else
- spiderfying disappears while clicking on another marker not belonging to the spiderfied group. This action willl open a new spider group if it is the case or just the correpsondent pop up.
Spiderfying is applied to all observations layers, i.e. new observations, historic observations and absences (still empty).


### New observations

![image](https://github.com/user-attachments/assets/f307c837-5ca3-41e0-bb44-d4c62e07204a)


### Historic observations

![image](https://github.com/user-attachments/assets/eb26ded6-5533-42b6-9288-044001c32a00)
